### PR TITLE
Fix/issue 106

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -352,6 +352,7 @@ func newResourceController(client kubernetes.Interface, eventHandler handlers.Ha
 			newEvent.key, err = cache.MetaNamespaceKeyFunc(obj)
 			newEvent.eventType = "create"
 			newEvent.resourceType = resourceType
+			newEvent.namespace = utils.GetObjectMetaData(obj).Namespace
 			logrus.WithField("pkg", "kubewatch-"+resourceType).Infof("Processing add to %v: %s", resourceType, newEvent.key)
 			if err == nil {
 				queue.Add(newEvent)
@@ -361,6 +362,7 @@ func newResourceController(client kubernetes.Interface, eventHandler handlers.Ha
 			newEvent.key, err = cache.MetaNamespaceKeyFunc(old)
 			newEvent.eventType = "update"
 			newEvent.resourceType = resourceType
+			newEvent.namespace = utils.GetObjectMetaData(new).Namespace
 			logrus.WithField("pkg", "kubewatch-"+resourceType).Infof("Processing update to %v: %s", resourceType, newEvent.key)
 			if err == nil {
 				queue.Add(newEvent)
@@ -477,6 +479,7 @@ func (c *Controller) processItem(newEvent Event) error {
 		kbEvent := event.Event{
 			Kind: newEvent.resourceType,
 			Name: newEvent.key,
+			Namespace: newEvent.namespace,
 		}
 		c.eventHandler.ObjectUpdated(obj, kbEvent)
 		return nil

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	apps_v1 "k8s.io/api/apps/v1"
+	apps_v1beta1 "k8s.io/api/apps/v1beta1"
 	batch_v1 "k8s.io/api/batch/v1"
 	api_v1 "k8s.io/api/core/v1"
         ext_v1beta1 "k8s.io/api/extensions/v1beta1"
@@ -57,9 +58,13 @@ func GetObjectMetaData(obj interface{}) meta_v1.ObjectMeta {
 	switch object := obj.(type) {
 	case *apps_v1.Deployment:
 		objectMeta = object.ObjectMeta
+	case *apps_v1beta1.Deployment:
+		objectMeta = object.ObjectMeta
 	case *api_v1.ReplicationController:
 		objectMeta = object.ObjectMeta
 	case *apps_v1.ReplicaSet:
+		objectMeta = object.ObjectMeta
+	case *ext_v1beta1.ReplicaSet:
 		objectMeta = object.ObjectMeta
 	case *apps_v1.DaemonSet:
 		objectMeta = object.ObjectMeta
@@ -74,6 +79,8 @@ func GetObjectMetaData(obj interface{}) meta_v1.ObjectMeta {
 	case *api_v1.Namespace:
 		objectMeta = object.ObjectMeta
 	case *api_v1.Secret:
+		objectMeta = object.ObjectMeta
+	case *api_v1.ConfigMap:
 		objectMeta = object.ObjectMeta
 	case *ext_v1beta1.Ingress:
 		objectMeta = object.ObjectMeta


### PR DESCRIPTION
Hi,
Fix for https://github.com/bitnami-labs/kubewatch/issues/106

Additionally add missing `confimap` and beta-versions for `replicaset` and `deployment` while fetching from `GetObjectMetaData` for a broader kubernetes version compatibility of kubewatch.

Validated using webhook handler by creating a deployment in a 1.6.6 cluster.
```
{"text":"A `deployment` in namespace `default` has been `created`:\n`kubewatch3`"}
{"text":"A `replica set` in namespace `default` has been `created`:\n`kubewatch3-2978672588`"}
{"text":"A `deployment` in namespace `default` has been `updated`:\n`default/kubewatch3`"}
{"text":"A `pod` in namespace `default` has been `created`:\n`kubewatch3-2978672588-pp26h`"}
{"text":"A `replicaset` in namespace `default` has been `updated`:\n`default/kubewatch3-2978672588`"}
{"text":"A `deployment` in namespace `default` has been `updated`:\n`default/kubewatch3`"}
{"text":"A `pod` in namespace `default` has been `updated`:\n`default/kubewatch3-2978672588-pp26h`"}
{"text":"A `replicaset` in namespace `default` has been `updated`:\n`default/kubewatch3-2978672588`"}
{"text":"A `deployment` in namespace `default` has been `updated`:\n`default/kubewatch3`"}
{"text":"A `pod` in namespace `default` has been `updated`:\n`default/kubewatch3-2978672588-pp26h`"}
{"text":"A `deployment` in namespace `default` has been `updated`:\n`default/kubewatch3`"}
{"text":"A `replicaset` in namespace `default` has been `updated`:\n`default/kubewatch3-2978672588`"}
{"text":"A `pod` in namespace `default` has been `updated`:\n`default/kubewatch3-2978672588-pp26h`"}
```

I hope this makes sense.

Cheers

